### PR TITLE
Resolved issue with faraday gem namespace changes in v0.8x. Moved from t...

### DIFF
--- a/lib/windy.rb
+++ b/lib/windy.rb
@@ -1,4 +1,4 @@
-require 'faraday'
+require 'faraday_middleware'
 require 'multi_json'
 
 module Windy

--- a/windy.gemspec
+++ b/windy.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
 
   s.files = ["README.md", "lib/windy.rb"]
 
-  s.add_dependency "faraday",    "~> 0.7"
+  s.add_dependency "faraday_middleware",    "~> 0.8"
   s.add_dependency "multi_json", "~> 1.0"
   s.add_development_dependency 'rspec', '~> 2.6'
   s.add_development_dependency 'simplecov', '~> 0.4'


### PR DESCRIPTION
Modified windy to use the faraday_middleware gem and not the original faraday gem, as the namespaces have been restructured across different faraday gems from around version 0.8x 
